### PR TITLE
fix bug

### DIFF
--- a/lib/board.dart
+++ b/lib/board.dart
@@ -192,6 +192,7 @@ class BoardState extends State<Board> {
   void open(int x, int y) {
     if (!inBoard(x, y)) return;
     if (uiState[y][x] == TileState.open) return;
+    if (uiState[y][x] == TileState.flagged) --minesFound;
     uiState[y][x] = TileState.open;
 
     if (mineCount(x, y) > 0) return;


### PR DESCRIPTION
If user miss a flag, the number of minesFound is updated when TileState is open.
otherwise the game cannot be won.